### PR TITLE
correction of last PR

### DIFF
--- a/core/src/main/java/ninja/soroosh/chatopia/core/runner/SimpleCommandRunner.java
+++ b/core/src/main/java/ninja/soroosh/chatopia/core/runner/SimpleCommandRunner.java
@@ -28,8 +28,10 @@ public class SimpleCommandRunner implements CommandRunner {
     @Override
     public Response run(final Command command, final Context context) {
         final Optional<Rule> maybeMatchedRule = this.rules.stream()
-                .filter(rule -> command.name().startsWith(rule.getCommandName())
-                || command.name().equals(rule.getCommandName()))
+                .filter(rule ->
+                        (command.name().startsWith(rule.getCommandName().split("\\s")[0])
+                                && rule.getCommandName().endsWith(" *"))
+                                || command.name().equals(rule.getCommandName()))
                 .findFirst();
         if (maybeMatchedRule.isEmpty()) {
             if (command.name().equals("help")) {

--- a/core/src/main/java/ninja/soroosh/chatopia/core/runner/SimpleCommandRunner.java
+++ b/core/src/main/java/ninja/soroosh/chatopia/core/runner/SimpleCommandRunner.java
@@ -28,7 +28,8 @@ public class SimpleCommandRunner implements CommandRunner {
     @Override
     public Response run(final Command command, final Context context) {
         final Optional<Rule> maybeMatchedRule = this.rules.stream()
-                .filter(rule -> rule.getCommandName().equals(command.name()))
+                .filter(rule -> command.name().startsWith(rule.getCommandName())
+                || command.name().equals(rule.getCommandName()))
                 .findFirst();
         if (maybeMatchedRule.isEmpty()) {
             if (command.name().equals("help")) {

--- a/core/src/main/java/ninja/soroosh/chatopia/core/runner/SimpleCommandRunner.java
+++ b/core/src/main/java/ninja/soroosh/chatopia/core/runner/SimpleCommandRunner.java
@@ -30,10 +30,9 @@ public class SimpleCommandRunner implements CommandRunner {
     @Override
     public Response run(final Command command, final Context context) {
         final Optional<Rule> maybeMatchedRule = this.rules.stream()
-                .filter(rule ->
-                        (command.name().startsWith(rule.getCommandName().split("\\s")[0])
-                                && rule.getCommandName().endsWith(" *"))
-                                || command.name().equals(rule.getCommandName()))
+                .filter(rule -> command.name().equals(rule.getCommandName())
+                        || (rule.getCommandName().endsWith(" *")
+                        && command.name().startsWith(rule.getCommandName().substring(0, rule.getCommandName().lastIndexOf("\s")))))
                 .findFirst();
         if (maybeMatchedRule.isEmpty()) {
             if (command.name().equals("help")) {

--- a/examples/src/main/java/ninja/soroosh/chatopia/core/example/MessageEchoExample.java
+++ b/examples/src/main/java/ninja/soroosh/chatopia/core/example/MessageEchoExample.java
@@ -12,7 +12,8 @@ import java.util.Optional;
 public class MessageEchoExample {
     @OnCommand(value = "echo", help = "This command echo")
     public Response onEchoCommand(String message, Context context) {
-        return () -> "echo " + message;
+        return () -> "your command is: echo"
+                +"\n and your whole message is: " + message;
     }
 
     @OnCommand(value = "hi", help = "start a chat")

--- a/examples/src/main/java/ninja/soroosh/chatopia/core/example/MessageEchoExample.java
+++ b/examples/src/main/java/ninja/soroosh/chatopia/core/example/MessageEchoExample.java
@@ -16,6 +16,12 @@ public class MessageEchoExample {
                 +"\n and your whole message is: " + message;
     }
 
+    @OnCommand(value = "echo *", help = "This command echo")
+    public Response onEchoStarCommand(String message, Context context) {
+        return () -> "your command is: echo star, meaning that it differs from echo itself"
+                +"\n and your whole message is: " + message;
+    }
+
     @OnCommand(value = "hi", help = "start a chat")
     public Response onHiCommand(String message, Context context) {
         final Session session = context.getSession().get();


### PR DESCRIPTION
now is possible to have rules with space and also having * at the end to extend possibility.
checked with following:

@OnCommand(value = "a", help = "This command echo")
    public Response onACommand(String message, Context context) {
        return () -> "command a: " + message;
    }
    @OnCommand(value = "ab", help = "This command echo")
    public Response onABCommand(String message, Context context) {
        return () -> "command ab: " + message;
    }
    @OnCommand(value = "abc", help = "This command echo")
    public Response onABCCommand(String message, Context context) {
        return () -> "command abc: " + message;
    }
    @OnCommand(value = "ab *", help = "This command echo")
    public Response onABStarCommand(String message, Context context) {
        return () -> "command ab *: " + message;
    }